### PR TITLE
update config for common structure of modern macOS JDKs

### DIFF
--- a/jetty-setuid/libsetuid-osx/pom.xml
+++ b/jetty-setuid/libsetuid-osx/pom.xml
@@ -44,8 +44,8 @@
         <artifactId>native-maven-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
-          <javahOS>mac</javahOS>
-          <jdkIncludePath>/System/Library/Frameworks/JavaVM.framework/Headers</jdkIncludePath>
+          <javahOS>darwin</javahOS>
+          <jdkIncludePath>${java.home}/include</jdkIncludePath>
           <compilerStartOptions>
             <compilerStartOption>-fPIC -O</compilerStartOption>
           </compilerStartOptions>


### PR DESCRIPTION
Not sure if the older macOS Java paths are still being used by this project, but a lot of modern JDK distributions seem to have similar directory structure of `$JAVA_HOME/include` for headers with `darwin` as subdirectory.

I needed to change paths to build `libsetuid-osx.so`. With this, I was able to build an ARM64 copy needed by Homebrew to distribute `jetty` for Apple Silicon machines https://github.com/Homebrew/homebrew-core/pull/111978

---

I see Temurin, Oracle, Zulu, and Microsoft all follow this directory structure:
```console
❯ ls /Library/Java/**/include/darwin
/Library/Java/JavaVirtualMachines/jdk-19.jdk/Contents/Home/include/darwin:
jawt_md.h  jni_md.h

/Library/Java/JavaVirtualMachines/microsoft-17.jdk/Contents/Home/include/darwin:
jawt_md.h  jni_md.h

/Library/Java/JavaVirtualMachines/temurin-19.jdk/Contents/Home/include/darwin:
jawt_md.h  jni_md.h

/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/include/darwin:
jawt_md.h  jni_md.h

/Library/Java/JavaVirtualMachines/zulu-19.jdk/Contents/Home/include/darwin:
jawt_md.h  jni_md.h
```